### PR TITLE
Fix crop for vertical images

### DIFF
--- a/Codec/Picture/Extra.hs
+++ b/Codec/Picture/Extra.hs
@@ -97,7 +97,7 @@ crop x' y' w' h' img@Image {..} =
     x = min (imageWidth  - 1) x'
     y = min (imageHeight - 1) y'
     w = min (imageWidth  - x) w'
-    h = min (imageWidth  - y) h'
+    h = min (imageHeight  - y) h'
 {-# INLINEABLE crop #-}
 
 -- | Flip an image horizontally.

--- a/tests/Codec/Picture/ExtraSpec.hs
+++ b/tests/Codec/Picture/ExtraSpec.hs
@@ -43,12 +43,17 @@ scaleBilinearSpec = do
         "data-examples/lenna-scaled-up.png"
 
 cropSpec :: Spec
-cropSpec =
-  context "when we pass arguments within image size" $
+cropSpec = do
+  context "when we pass arguments within image size (square)" $
     it "produces correct image" $
       checkWithFiles (crop 211 210 178 191)
         "data-examples/lenna.png"
         "data-examples/lenna-cropped.png"
+  context "when we pass arguments within image size (vertical)" $
+    it "produces correct image" $
+      checkWithFiles (crop 0 512 512 512)
+        "data-examples/lenna-below.png"
+        "data-examples/lenna.png"
 
 flipHorizontallySpec :: Spec
 flipHorizontallySpec =


### PR DESCRIPTION
Check this line: `h = min (imageWidth  - y) h'`
The test was working only because of a coincidence.