### PR TITLE
Allow for other bounded integrals than Pixel8.

### DIFF
--- a/Codec/Picture/Extra.hs
+++ b/Codec/Picture/Extra.hs
@@ -12,6 +12,8 @@
 {-# LANGUAGE CPP              #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RecordWildCards  #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE RankNTypes  #-}
 
 module Codec.Picture.Extra
   ( -- * Scaling
@@ -36,7 +38,7 @@ import qualified Codec.Picture.Types as M
 
 -- | Scale an image using bi-linear interpolation.
 
-scaleBilinear :: (Pixel a, Integral (PixelBaseComponent a))
+scaleBilinear :: (Pixel a, Bounded (PixelBaseComponent a), Integral (PixelBaseComponent a))
   => Int               -- ^ Desired width
   -> Int               -- ^ Desired height
   -> Image a           -- ^ Original image
@@ -94,11 +96,11 @@ mulp :: (Pixel a, Integral (PixelBaseComponent a)) => a -> Float -> a
 mulp pixel x = colorMap (floor . (* x) . fromIntegral) pixel
 {-# INLINE mulp #-}
 
-addp :: (Pixel a, Integral (PixelBaseComponent a)) => a -> a -> a
+addp :: forall a. (Pixel a, Bounded (PixelBaseComponent a), Integral (PixelBaseComponent a)) => a -> a -> a
 addp = mixWith (const f)
   where
     f x y = fromIntegral $
-      (0xff :: Pixel8) `min` (fromIntegral x + fromIntegral y)
+      (maxBound :: PixelBaseComponent a) `min` (fromIntegral x + fromIntegral y)
 {-# INLINE addp #-}
 
 -- | Crop a given image. If supplied coordinates are greater than size of


### PR DESCRIPTION
The `min` with 0xff results in too small values when used
with 16 bit pixel values.