### PR TITLE
Test with GHC 8.6.1 and ‘cabal-install-2.4’

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,16 @@ cache:
 
 matrix:
   include:
-    - env: CABALVER=2.2 GHCVER=7.8.4
-      addons: {apt: {packages: [cabal-install-2.2,ghc-7.8.4,],sources: [hvr-ghc]}}
-    - env: CABALVER=2.2 GHCVER=7.10.3
-      addons: {apt: {packages: [cabal-install-2.2,ghc-7.10.3],sources: [hvr-ghc]}}
-    - env: CABALVER=2.2 GHCVER=8.0.2
-      addons: {apt: {packages: [cabal-install-2.2,ghc-8.0.2],sources: [hvr-ghc]}}
-    - env: CABALVER=2.2 GHCVER=8.2.2
-      addons: {apt: {packages: [cabal-install-2.2,ghc-8.2.2],sources: [hvr-ghc]}}
-    - env: CABALVER=2.2 GHCVER=8.4.3
-      addons: {apt: {packages: [cabal-install-2.2,ghc-8.4.3],sources: [hvr-ghc]}}
+    - env: CABALVER=2.4 GHCVER=7.10.3
+      addons: {apt: {packages: [cabal-install-2.4,ghc-7.10.3],sources: [hvr-ghc]}}
+    - env: CABALVER=2.4 GHCVER=8.0.2
+      addons: {apt: {packages: [cabal-install-2.4,ghc-8.0.2],sources: [hvr-ghc]}}
+    - env: CABALVER=2.4 GHCVER=8.2.2
+      addons: {apt: {packages: [cabal-install-2.4,ghc-8.2.2],sources: [hvr-ghc]}}
+    - env: CABALVER=2.4 GHCVER=8.4.3
+      addons: {apt: {packages: [cabal-install-2.4,ghc-8.4.3],sources: [hvr-ghc]}}
+    - env: CABALVER=2.4 GHCVER=8.6.1
+      addons: {apt: {packages: [cabal-install-2.4,ghc-8.6.1],sources: [hvr-ghc]}}
 
 before_install:
   - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH

--- a/JuicyPixels-extra.cabal
+++ b/JuicyPixels-extra.cabal
@@ -1,7 +1,7 @@
 name:                 JuicyPixels-extra
 version:              0.4.0
 cabal-version:        1.18
-tested-with:          GHC==7.8.4, GHC==7.10.3, GHC==8.0.2, GHC==8.2.2, GHC==8.4.3
+tested-with:          GHC==7.10.3, GHC==8.0.2, GHC==8.2.2, GHC==8.4.3, GHC==8.6.1
 license:              BSD3
 license-file:         LICENSE.md
 author:               Mark Karpov <markkarpov92@gmail.com>
@@ -26,7 +26,7 @@ flag dev
   default:            False
 
 library
-  build-depends:      base              >= 4.7 && < 5
+  build-depends:      base              >= 4.8 && < 5
                     , JuicyPixels       >= 3.2.6.4 && < 3.4
   exposed-modules:    Codec.Picture.Extra
   if flag(dev)
@@ -45,7 +45,7 @@ test-suite tests
   main-is:            Spec.hs
   hs-source-dirs:     tests
   type:               exitcode-stdio-1.0
-  build-depends:      base              >= 4.7 && < 5
+  build-depends:      base              >= 4.8 && < 5
                     , JuicyPixels       >= 3.2.6.4 && < 3.4
                     , JuicyPixels-extra
                     , hspec             >= 2.0
@@ -61,7 +61,7 @@ benchmark bench
   main-is:            Main.hs
   hs-source-dirs:     bench
   type:               exitcode-stdio-1.0
-  build-depends:      base              >= 4.7 && < 5.0
+  build-depends:      base              >= 4.8 && < 5.0
                     , JuicyPixels       >= 3.2.6.4 && < 3.4
                     , JuicyPixels-extra
                     , criterion         >= 0.6.2.1 && < 1.6


### PR DESCRIPTION
Also drop support for GHC 7.8.