### PR TITLE
Use build-tool-depends instead of build-tools

### DIFF
--- a/JuicyPixels-extra.cabal
+++ b/JuicyPixels-extra.cabal
@@ -45,12 +45,12 @@ library
             -Wnoncanonical-monad-instances
 
 test-suite tests
-    type:             exitcode-stdio-1.0
-    main-is:          Spec.hs
-    build-tools:      hspec-discover >=2.0 && <3.0
-    hs-source-dirs:   tests
-    other-modules:    Codec.Picture.ExtraSpec
-    default-language: Haskell2010
+    type:               exitcode-stdio-1.0
+    main-is:            Spec.hs
+    build-tool-depends: hspec-discover:hspec-discover >=2.0 && <3.0
+    hs-source-dirs:     tests
+    other-modules:      Codec.Picture.ExtraSpec
+    default-language:   Haskell2010
     build-depends:
         base >=4.15 && <5,
         JuicyPixels >=3.2.6.4 && <3.4,


### PR DESCRIPTION
The latter is deprecated in the Cabal specification 2.0.